### PR TITLE
Add base metadata and make metadata in pages optional

### DIFF
--- a/content/about-me/index-1.md
+++ b/content/about-me/index-1.md
@@ -1,7 +1,7 @@
 ---
-aboutPageTitle: About me title
-aboutPageDescription: About me description
-aboutPageImage: MarleneWatson.png
+aboutPageTitle:
+aboutPageDescription:
+aboutPageImage:
 description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce
   iaculis ultricies eros, ac iaculis eros maximus nec. Phasellus vitae mi felis.
   Curabitur iaculis nunc laoreet eleifend tincidunt. Aliquam nec lectus varius,

--- a/content/blog/index-1.md
+++ b/content/blog/index-1.md
@@ -1,9 +1,7 @@
 ---
-blogPageTitle: Blog page title
-blogPageDescription: "Blog page description Blog page description Blog page
-  description Blog page description Blog page description Blog page description
-  Blog page description "
-blogPageImage: background.jpg
+blogPageTitle:
+blogPageDescription:
+blogPageImage:
 blogPost:
   - blogTitle: Blog Post Title
     blogLabel: Blog Post Label

--- a/content/contact/index-1.md
+++ b/content/contact/index-1.md
@@ -1,5 +1,5 @@
 ---
-contactPageTitle: Contact page title
-contactPageDescription: Contact page description
-contactPageImage: background.jpg
+contactPageTitle:
+contactPageDescription:
+contactPageImage:
 ---

--- a/content/metadata/index-1.md
+++ b/content/metadata/index-1.md
@@ -1,3 +1,7 @@
 ---
-metadataFavicon: screenshot-2020-11-12-at-22.10.49.png
+defaultPageTitle: Default page title
+defaultPageDescription: Default page description
+defaultPageImage: screenshot-2020-11-12-at-22.10.49.png
+favicon: screenshot-2020-11-12-at-22.10.49.png
+websiteLanguage: en
 ---

--- a/content/portfolio/index-1.md
+++ b/content/portfolio/index-1.md
@@ -1,7 +1,7 @@
 ---
-portfolioPageTitle: My portfolio page
-portfolioPageDescription: My portfolio page description
-portfolioPageImage: background.jpg
+portfolioPageTitle:
+portfolioPageDescription:
+portfolioPageImage:
 projects:
   - projectLabel: Mobile app
     projectCode: https://github.com/CodersCrew/CodersCard

--- a/content/resume/index-1.md
+++ b/content/resume/index-1.md
@@ -1,7 +1,7 @@
 ---
-resumePageTitle: resume page
-resumePageDescription: resume page description
-resumePageImage: background.jpg
+resumePageTitle:
+resumePageDescription:
+resumePageImage:
 workExperience:
   - startJobDate: 2019-11-02T20:06:48.583Z
     finishJobDate: 2020-11-01T20:06:48.592Z

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,7 @@
+import './src/styles/global.css';
+
 import React from 'react';
 
-import './src/styles/global.css';
 import TopLayout from './src/components/TopLayout';
 
 export const wrapRootElement = ({ element }) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,6 +5,21 @@ exports.createSchemaCustomization = ({ actions }) => {
       frontmatter: Frontmatter
     }
     type Frontmatter @infer {
+      aboutPageTitle: String
+      blogPageTitle: String
+      resumePageTitle: String
+      portfolioPageTitle: String
+      contactPageTitle: String
+      aboutPageDescription: String
+      blogPageDescription: String
+      resumePageDescription: String
+      portfolioPageDescription: String
+      contactPageDescription: String
+      aboutPageImage: File @fileByRelativePath
+      blogPageImage: File @fileByRelativePath
+      resumePageImage: File @fileByRelativePath
+      portfolioPageImage: File @fileByRelativePath
+      contactPageImage: File @fileByRelativePath
       blogPost: [MarkdownRemarkFrontmatterBlogPost]
       testimonials: [MarkdownRemarkFrontmatterTestimonial]
     }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -11,9 +11,9 @@ type LayoutProps = {
   children: ReactNode;
   developerProfile: DeveloperProfileGQL;
   meta: {
-    title: string;
-    description: string;
-    imageUrl: string;
+    title?: string;
+    description?: string;
+    imageUrl?: string;
   };
   variant?: 'default' | 'withDetailsCard';
 };
@@ -83,7 +83,6 @@ export const Layout = ({ children, developerProfile, meta, variant = 'default' }
   return (
     <Container className={classes.container} maxWidth="lg">
       <SEO
-        lang="en"
         title={meta.title}
         description={meta.description}
         author={`${developerProfile.firstName} ${developerProfile.lastName}`}

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -3,43 +3,76 @@ import { Helmet } from 'react-helmet';
 import { graphql, useStaticQuery } from 'gatsby';
 
 type SEOProps = {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
+  image?: string;
   author: string;
-  lang: string;
 };
 
-function SEO({ description, title, author, lang }: SEOProps) {
-  const data: { meta: { frontmatter: { metadataFavicon: { publicURL: string } } } } = useStaticQuery(graphql`
+type MetadataGQL = {
+  meta: {
+    frontmatter: {
+      defaultPageTitle: string;
+      defaultPageDescription: string;
+      defaultPageImage: {
+        publicURL: string;
+      };
+      favicon: {
+        publicURL: string;
+      };
+      websiteLanguage: string;
+    };
+  };
+};
+
+function SEO({ description, title, image, author }: SEOProps) {
+  const {
+    meta: { frontmatter: metadata },
+  }: MetadataGQL = useStaticQuery(graphql`
     query {
       meta: markdownRemark(fileAbsolutePath: { regex: "/metadata/index-1.md/" }) {
         frontmatter {
-          metadataFavicon {
+          defaultPageTitle
+          defaultPageDescription
+          defaultPageImage {
             publicURL
           }
+          favicon {
+            publicURL
+          }
+          websiteLanguage
         }
       }
     }
   `);
 
+  const pageDescription = description ?? metadata.defaultPageDescription;
+  const pageTitle = title ?? metadata.defaultPageTitle;
+  const pagePreviewImage = image ?? metadata.defaultPageImage.publicURL;
+  const websiteLanguage = metadata.websiteLanguage ?? 'en';
+
   return (
     <Helmet
       htmlAttributes={{
-        lang,
+        lang: websiteLanguage,
       }}
-      title={title}
+      title={pageTitle}
       meta={[
         {
           name: `description`,
-          content: description,
+          content: pageDescription,
         },
         {
           property: `og:title`,
-          content: title,
+          content: pageTitle,
         },
         {
           property: `og:description`,
-          content: description,
+          content: pageDescription,
+        },
+        {
+          property: 'og:image',
+          content: pagePreviewImage,
         },
         {
           property: `og:type`,
@@ -50,22 +83,26 @@ function SEO({ description, title, author, lang }: SEOProps) {
           content: `summary`,
         },
         {
+          name: `twitter:image`,
+          content: pagePreviewImage,
+        },
+        {
           name: `twitter:creator`,
           content: author,
         },
         {
           name: `twitter:title`,
-          content: title,
+          content: pageTitle,
         },
         {
           name: `twitter:description`,
-          content: description,
+          content: pageDescription,
         },
       ]}
     >
-      <link rel="icon" type="image/png" sizes="16x16" href={data.meta.frontmatter.metadataFavicon.publicURL} />
-      <link rel="icon" type="image/png" sizes="16x16" href={data.meta.frontmatter.metadataFavicon.publicURL} />
-      <link rel="icon" type="image/png" sizes="32x32" href={data.meta.frontmatter.metadataFavicon.publicURL} />
+      <link rel="icon" type="image/png" sizes="16x16" href={metadata.favicon.publicURL} />
+      <link rel="icon" type="image/png" sizes="16x16" href={metadata.favicon.publicURL} />
+      <link rel="icon" type="image/png" sizes="32x32" href={metadata.favicon.publicURL} />
     </Helmet>
   );
 }

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -118,9 +118,9 @@ const BlogPage: FC<{ data: BlogGQL }> = ({ data }) => {
     <Layout
       developerProfile={developerProfile}
       meta={{
-        title: blogData.blogPageTitle ?? 'Blog page',
-        description: blogData.blogPageDescription ?? 'This is a blog page',
-        imageUrl: blogData.blogPageImage.publicURL,
+        title: blogData.blogPageTitle,
+        description: blogData.blogPageDescription,
+        imageUrl: blogData.blogPageImage?.publicURL,
       }}
     >
       <Box className={classes.blogContainer}>

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -161,7 +161,7 @@ const ContactPage: FC<{ data: ContactGQL }> = ({ data }) => {
       meta={{
         title: contactData.contactPageTitle,
         description: contactData.contactPageDescription,
-        imageUrl: contactData.contactPageImage.publicURL,
+        imageUrl: contactData.contactPageImage?.publicURL,
       }}
       variant="withDetailsCard"
     >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,7 @@ const About: FC<{ data: AboutPageData }> = ({ data }) => {
       meta={{
         title: aboutData.aboutPageTitle,
         description: aboutData.aboutPageDescription,
-        imageUrl: aboutData.aboutPageImage.publicURL,
+        imageUrl: aboutData.aboutPageImage?.publicURL,
       }}
       variant="withDetailsCard"
     >

--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -153,7 +153,7 @@ const PortfolioPage: FC<{ data: ProjectGQL }> = ({ data }) => {
       meta={{
         title: projectData.portfolioPageTitle,
         description: projectData.portfolioPageDescription,
-        imageUrl: projectData.portfolioPageImage.publicURL,
+        imageUrl: projectData.portfolioPageImage?.publicURL,
       }}
     >
       <Box className={classes.projectsContainer}>

--- a/src/pages/resume/index.tsx
+++ b/src/pages/resume/index.tsx
@@ -52,7 +52,7 @@ const ResumePage: FC<{ data: ResumePageData }> = ({ data }) => {
       meta={{
         title: resumeData.resumePageTitle,
         description: resumeData.resumePageDescription,
-        imageUrl: resumeData.resumePageImage.publicURL,
+        imageUrl: resumeData.resumePageImage?.publicURL,
       }}
     >
       <Box className={classes.resumePageContainer}>

--- a/src/views/about/types.ts
+++ b/src/views/about/types.ts
@@ -3,10 +3,10 @@ import { LevelRange } from '../../components/Skill';
 export type AboutPageData = {
   aboutPage: {
     frontmatter: {
-      aboutPageTitle: string;
-      aboutPageDescription: string;
-      aboutPageImage: {
-        publicURL: string;
+      aboutPageTitle?: string;
+      aboutPageDescription?: string;
+      aboutPageImage?: {
+        publicURL?: string;
       };
       description: string;
       socialMedia: {

--- a/src/views/blog-page/types.ts
+++ b/src/views/blog-page/types.ts
@@ -13,9 +13,9 @@ export type BlogGQL = {
   markdownRemark: {
     blogPage: {
       blogPageTitle?: string;
-      blogPageDescription: string;
-      blogPageImage: {
-        publicURL: string;
+      blogPageDescription?: string;
+      blogPageImage?: {
+        publicURL?: string;
       };
       blogPost?: BlogPostType[];
     };

--- a/src/views/contact-page/types.ts
+++ b/src/views/contact-page/types.ts
@@ -1,10 +1,10 @@
 export type ContactGQL = {
   contactPage: {
     frontmatter: {
-      contactPageTitle: string;
-      contactPageDescription: string;
-      contactPageImage: {
-        publicURL: string;
+      contactPageTitle?: string;
+      contactPageDescription?: string;
+      contactPageImage?: {
+        publicURL?: string;
       };
     };
   };

--- a/src/views/portfolio-page/types.ts
+++ b/src/views/portfolio-page/types.ts
@@ -20,10 +20,10 @@ export type ProjectType = {
 export type ProjectGQL = {
   portfolioPage: {
     frontmatter: {
-      portfolioPageTitle: string;
-      portfolioPageDescription: string;
-      portfolioPageImage: {
-        publicURL: string;
+      portfolioPageTitle?: string;
+      portfolioPageDescription?: string;
+      portfolioPageImage?: {
+        publicURL?: string;
       };
       projects: ProjectType[];
     };

--- a/src/views/resume-page/types.ts
+++ b/src/views/resume-page/types.ts
@@ -1,10 +1,10 @@
 export type ResumePageData = {
   resumePage: {
     frontmatter: {
-      resumePageTitle: string;
-      resumePageDescription: string;
-      resumePageImage: {
-        publicURL: string;
+      resumePageTitle?: string;
+      resumePageDescription?: string;
+      resumePageImage?: {
+        publicURL?: string;
       };
       workExperience: {
         startJobDate: string;

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -28,9 +28,15 @@ collections:
           label: "Page Description",
           name: "blogPageDescription",
           widget: "string",
+          required: false,
           pattern: [".{50,160}", "Must have 50-160 characters"],
         }
-      - { label: "Page preview image", name: "blogPageImage", widget: "image" }
+      - {
+          label: "Page preview image",
+          name: "blogPageImage",
+          widget: "image",
+          required: false,
+        }
       - label: "Blog post"
         name: "blogPost"
         widget: "list"
@@ -196,16 +202,22 @@ collections:
           label: "Page Title",
           name: "aboutPageTitle",
           widget: "string",
-          default: "About me",
+          required: false,
           pattern: [".{5,60}", "Must have 5-60 characters"],
         }
       - {
           label: "Page Description",
           name: "aboutPageDescription",
           widget: "string",
+          required: false,
           pattern: [".{50,160}", "Must have 50-160 characters"],
         }
-      - { label: "Page preview image", name: "aboutPageImage", widget: "image" }
+      - {
+          label: "Page preview image",
+          name: "aboutPageImage",
+          widget: "image",
+          required: false,
+        }
       - {
           label: "Description",
           name: "description",
@@ -310,18 +322,21 @@ collections:
           label: "Page Title",
           name: "resumePageTitle",
           widget: "string",
+          required: false,
           pattern: [".{5,60}", "Must have 5-60 characters"],
         }
       - {
           label: "Page Description",
           name: "resumePageDescription",
           widget: "string",
+          required: false,
           pattern: [".{50,160}", "Must have 50-160 characters"],
         }
       - {
           label: "Page preview image",
           name: "resumePageImage",
           widget: "image",
+          required: false,
         }
       - label: "Work experience"
         name: "workExperience"
@@ -391,18 +406,21 @@ collections:
           label: "Page Title",
           name: "portfolioPageTitle",
           widget: "string",
+          required: false,
           pattern: [".{5,60}", "Must have 5-60 characters"],
         }
       - {
           label: "Page Description",
           name: "portfolioPageDescription",
           widget: "string",
+          required: false,
           pattern: [".{50,160}", "Must have 50-160 characters"],
         }
       - {
           label: "Page preview image",
           name: "portfolioPageImage",
           widget: "image",
+          required: false,
         }
       - label: "Projects"
         name: "projects"
@@ -507,18 +525,21 @@ collections:
           label: "Page Title",
           name: "contactPageTitle",
           widget: "string",
+          required: false,
           pattern: [".{5,60}", "Must have 5-60 characters"],
         }
       - {
           label: "Page Description",
           name: "contactPageDescription",
           widget: "string",
+          required: false,
           pattern: [".{50,160}", "Must have 50-160 characters"],
         }
       - {
           label: "Page preview image",
           name: "contactPageImage",
           widget: "image",
+          required: false,
         }
   - name: "metadata"
     label: "Metadata"
@@ -548,9 +569,13 @@ collections:
           name: "defaultPageImage",
           widget: "image",
         }
-      - { label: "Favicon", name: "metadataFavicon", widget: "image" }
-# TODO
-# make metadata on ALL PAGES optional and only default as required
-# apply in seo component
-# modify pages to validate if metadata is present, if not use default (SEO xomponent)
-# add more open graph properties if you wind any
+      - {
+          label: "Favicon - small icon visible in bookmarks and browser tabs",
+          name: "favicon",
+          widget: "image",
+        }
+      - {
+          label: "Website language code (ex. 'en', 'pl'",
+          name: "websiteLanguage",
+          widget: "string",
+        }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -575,7 +575,8 @@ collections:
           widget: "image",
         }
       - {
-          label: "Website language code (ex. 'en', 'pl'",
+          label: "Website language code (ex. 'en', 'pl')",
           name: "websiteLanguage",
           widget: "string",
+          pattern: ["^[a-z]{2}", "Must have exactly 2 lower-case characters"],
         }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -531,4 +531,26 @@ collections:
     editor:
       preview: false
     fields:
+      - {
+          label: "Default page title",
+          name: "defaultPageTitle",
+          widget: "string",
+          pattern: [".{5,60}", "Must have 5-60 characters"],
+        }
+      - {
+          label: "Default page description",
+          name: "defaultPageDescription",
+          widget: "string",
+          pattern: [".{50,160}", "Must have 50-160 characters"],
+        }
+      - {
+          label: "Default preview image",
+          name: "defaultPageImage",
+          widget: "image",
+        }
       - { label: "Favicon", name: "metadataFavicon", widget: "image" }
+# TODO
+# make metadata on ALL PAGES optional and only default as required
+# apply in seo component
+# modify pages to validate if metadata is present, if not use default (SEO xomponent)
+# add more open graph properties if you wind any


### PR DESCRIPTION
### Description
This PR adds base metadata for the website and makes page specific metadata optional.
Now the user is not required to specify different metadata for every page, but he can if he wished to do so. 🚀 

Closes #150 