### PR TITLE
[fix]: Favicon breaking the app fix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,8 @@ module.exports = {
         background_color: `#663399`,
         theme_color: `#663399`,
         display: `minimal-ui`,
+        icon: `${__dirname}/src/images/gatsby-icon.png`,
+        include_favicon: false, // exclude favicons
       },
     },
     `gatsby-plugin-netlify-cms`,


### PR DESCRIPTION
We are sourcing favicon from the CMS so we have to disable it in the plugin