### PR TITLE
Adapt DeveloperProfile card to match its mockups

### DIFF
--- a/src/components/DetailsCard/DetailsCardDesktop.tsx
+++ b/src/components/DetailsCard/DetailsCardDesktop.tsx
@@ -11,7 +11,6 @@ import { renderSocialMediaIcon } from './renderSocialMediaIcon';
 const useStyles = makeStyles((theme) => ({
   wrapper: {
     position: 'relative',
-    height: '100%',
     width: '100%',
     paddingTop: theme.spacing(14),
     background: 'transparent',
@@ -48,18 +47,17 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
   },
   basicInfo: {
+    padding: theme.spacing(2, 3, 3, 3),
     background: 'transparent',
-    height: '100%',
   },
   moreInfo: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'center',
     alignItems: 'flex-start',
     background: theme.palette.background.light,
-    padding: theme.spacing(3),
-    minHeight: 268,
+    padding: theme.spacing(3, 3, 5, 3),
     width: '100%',
+    height: '100%',
   },
   detailsItem: {
     marginBottom: theme.spacing(2),
@@ -68,7 +66,6 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.success.main,
   },
   name: {
-    paddingTop: theme.spacing(2),
     textAlign: 'center',
     wordWrap: 'break-word',
   },
@@ -104,7 +101,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     width: '100%',
     justifyContent: 'center',
-    paddingTop: theme.spacing(1.5),
+    marginTop: theme.spacing(2),
   },
   button: {
     width: 158,


### PR DESCRIPTION
### Description
I removed the fixed height and added paddings to position content within the card.
Now it should look correct 😄 

Closes #171 

### Screenshots
<img width="361" alt="Screenshot 2021-04-03 at 21 24 19" src="https://user-images.githubusercontent.com/39158460/113489189-0c403480-94c3-11eb-8b03-ada2138ab02a.png">
<img width="344" alt="Screenshot 2021-04-03 at 21 15 48" src="https://user-images.githubusercontent.com/39158460/113489193-1104e880-94c3-11eb-95e6-166b8bd5bbb0.png">
<img width="247" alt="Screenshot 2021-04-03 at 21 20 31" src="https://user-images.githubusercontent.com/39158460/113489198-14986f80-94c3-11eb-8b64-0eaf3f967433.png">
